### PR TITLE
Defer async hook dispatch so slow hooks no longer freeze the TUI

### DIFF
--- a/src/AgentRunner.zig
+++ b/src/AgentRunner.zig
@@ -621,20 +621,27 @@ pub fn serviceRoundTripEvent(
 ) bool {
     switch (event) {
         .hook_request => |req| {
+            // Async path defers: beginHook registers a PendingFire that owns
+            // req.done and fires it from the per-tick pump once every hook
+            // coroutine retires (with the aggregated veto). Only signal done
+            // here for the synchronous fallback (no async runtime / no hooks)
+            // or no engine — the agent thread parks on req.done until then.
+            var deferred = false;
             if (engine) |eng| {
-                const veto = eng.fireHook(req.payload) catch |err| blk: {
-                    log.warn("hook dispatch failed: {}", .{err});
-                    break :blk null;
-                };
-                if (veto) |reason| {
-                    req.cancelled = true;
-                    req.cancel_reason = reason;
+                if (eng.beginHook(req)) {
+                    deferred = true;
+                } else {
+                    const veto = eng.fireHook(req.payload) catch |err| blk: {
+                        log.warn("hook dispatch failed: {}", .{err});
+                        break :blk null;
+                    };
+                    if (veto) |reason| {
+                        req.cancelled = true;
+                        req.cancel_reason = reason;
+                    }
                 }
             }
-            // Always signal, even without an engine: the agent thread
-            // is parked on `req.done` and must be released so the
-            // tool call can proceed (or fail) cleanly.
-            req.done.set();
+            if (!deferred) req.done.set();
             return true;
         },
         .lua_tool_request => |req| {

--- a/src/Harness.zig
+++ b/src/Harness.zig
@@ -550,11 +550,12 @@ fn runWithProvider(deps: HeadlessDeps) !void {
     while (!done) {
         AgentRunner.dispatchHookRequests(&deps.runner.event_queue, deps.runner.lua_engine, deps.runner.window_manager);
 
-        // Advance any deferred round-trip (compaction) on the same main thread
-        // the interactive tick uses: abort fires whose turn was cancelled,
-        // then pump posted completions so the strategy coroutine retires and
-        // fires its req.done. Runs above the `count == 0` continue so an
-        // in-flight compaction makes progress even when no agent events arrive.
+        // Advance any deferred round-trip (compaction or async hooks) on the
+        // same main thread the interactive tick uses: abort fires whose turn
+        // was cancelled (and enforce hook budgets), then pump posted
+        // completions so the coroutine retires and fires its req.done. Runs
+        // above the `count == 0` continue so an in-flight fire makes progress
+        // even when no agent events arrive.
         if (deps.runner.lua_engine) |eng| {
             eng.cancelTriggeredFires();
             eng.pumpCompletions();

--- a/src/Hooks.zig
+++ b/src/Hooks.zig
@@ -180,6 +180,12 @@ pub const HookRequest = struct {
     /// path. Null for observer-only lifecycle hooks, which cannot veto and
     /// so never receive a reason.
     reason_allocator: ?Allocator = null,
+    /// Borrowed cancel flag of the producing turn, set by `marshalRequest`.
+    /// The deferred hook fire reads it (via its PendingFire) so the pump can
+    /// abort an in-flight async hook on Ctrl+C and shutdown can scope its
+    /// fire-release to this runner. Typed as the raw atomic to avoid a
+    /// Hooks<->agent_events import cycle; identical to `agent_events.CancelFlag`.
+    cancel: ?*std.atomic.Value(bool) = null,
 
     pub fn init(payload: *HookPayload) HookRequest {
         return .{

--- a/src/LuaEngine.zig
+++ b/src/LuaEngine.zig
@@ -2957,14 +2957,25 @@ pub const LuaEngine = struct {
                 // coroutine retires in a moment and the values disappear.
                 if (task.hook_payload) |hp| {
                     if (num_results >= 1 and task.co.isTable(-1)) {
-                        self.hook_dispatcher.applyHookReturnFromCoroutine(task.co, hp) catch |err| {
+                        const veto = self.hook_dispatcher.applyHookReturnFromCoroutine(task.co, hp) catch |err| blk: {
                             // Fail-soft: the hook ran to completion, but its return
                             // table couldn't be marshalled back into the payload.
                             // Discard the mutations and continue with subsequent hooks.
                             log.warn("hook return apply failed (kind={s}, task={d}): {}, discarding mutations", .{
                                 @tagName(hp.kind()), task.thread_ref, err,
                             });
+                            break :blk null;
                         };
+                        if (veto) |reason| {
+                            // Deferred round-trip hooks accumulate the veto on
+                            // their fire (scoped per fire); in-process hooks feed
+                            // the dispatcher's veto channel read by fireHook.
+                            if (task.pending_fire) |pf| {
+                                pf.recordVeto(reason, self.hook_dispatcher.allocator);
+                            } else {
+                                self.hook_dispatcher.setPendingCancel(reason);
+                            }
+                        }
                     }
                 } else if (task.compact_request) |req| {
                     // Compact-strategy retire path. The strategy's return

--- a/src/LuaEngine.zig
+++ b/src/LuaEngine.zig
@@ -194,6 +194,10 @@ pub const LuaEngine = struct {
     /// shutdown can release every producer parked on a request that was
     /// already pulled out of the event queue.
     pending_fires: std.ArrayList(*PendingFire) = .empty,
+    /// Set by `beginHook` for the duration of the dispatcher's spawn loop so
+    /// `sinkSpawnHook` binds each spawned hook coroutine to this deferred fire.
+    /// Null outside a deferred hook dispatch (the in-process `fireHook` path).
+    active_hook_fire: ?*PendingFire = null,
     /// Handlers registered via `zag.context.on_tool_result(name, fn)`.
     /// Keyed by tool name (the engine owns the key bytes; see `JitHandler`).
     /// Walked by `AgentRunner.dispatchHookRequests` when a
@@ -2289,6 +2293,50 @@ pub const LuaEngine = struct {
         return try self.hook_dispatcher.fireHook(payload, self.lua, &sink);
     }
 
+    /// Deferred async hook dispatch for the round-trip path (the
+    /// `.hook_request` arm). Spawns each matching hook coroutine bound to a
+    /// PendingFire that owns `req.done`; the per-tick pump advances them and
+    /// `finalizePendingFire` fires done (with the aggregated veto + the
+    /// re-entry-guard restore) once the last retires. Returns true when it took
+    /// ownership of `req.done` (deferred); false when there is no async runtime
+    /// or no hooks, so the caller runs the synchronous path and signals done.
+    pub fn beginHook(self: *LuaEngine, req: *Hooks.HookRequest) bool {
+        if (self.async_runtime == null) return false;
+        if (self.hook_dispatcher.registry.hooks.items.len == 0) return false;
+
+        const pf = self.allocator.create(PendingFire) catch return false;
+        pf.* = .{
+            .kind = .hook,
+            .done = &req.done,
+            .outstanding = 1, // setup guard, released below
+            .cancel = req.cancel,
+            .bound_hook_request = req,
+        };
+        self.pending_fires.append(self.allocator, pf) catch {
+            self.allocator.destroy(pf);
+            return false;
+        };
+        // `pf` is now registry-owned (freed by finalize). DO NOT add a fallible
+        // `try` below this point — it would leave req.done unsignalled.
+
+        const sink = hook_registry_mod.ResumeSink{
+            .ctx = self,
+            .spawnHookFn = sinkSpawnHook,
+            .drainOneFn = sinkDrainOne,
+            .isAliveFn = sinkIsAlive,
+            .enforceBudgetFn = sinkEnforceBudget,
+        };
+        self.active_hook_fire = pf;
+        const spawned = self.hook_dispatcher.beginHook(req.payload, self.lua, &sink);
+        self.active_hook_fire = null;
+        // Mark for the firing_depth decrement in finalize ONLY when the
+        // dispatcher actually incremented (spawned); a re-entry-capped fire
+        // leaves hook_event_kind null so finalize doesn't underflow the guard.
+        if (spawned) pf.hook_event_kind = req.payload.kind();
+        self.releaseFireGuard(pf);
+        return true;
+    }
+
     /// Invoke a zero-arg Lua callback stored at `ref` in the registry.
     /// Used by `WindowManager.executeAction` to dispatch
     /// `Keymap.Action.lua_callback` bindings. Errors are logged and
@@ -2311,6 +2359,12 @@ pub const LuaEngine = struct {
 
     fn sinkSpawnHook(ctx: *anyopaque, payload: *Hooks.HookPayload) anyerror!i32 {
         const self: *LuaEngine = @ptrCast(@alignCast(ctx));
+        // Deferred dispatch (beginHook) binds each hook to the active fire so
+        // its retirement decrements the fire and its veto routes per-fire; the
+        // in-process fireHook path leaves active_hook_fire null and parks.
+        if (self.active_hook_fire) |pf| {
+            return self.spawnCoroutineBoundToFire(1, payload, null, pf);
+        }
         return self.spawnHookCoroutine(1, null, payload);
     }
 
@@ -2849,15 +2903,30 @@ pub const LuaEngine = struct {
     /// coroutine on its next resume, firing the fire's `done`. Mirrors
     /// `sinkEnforceBudget`'s task scan.
     pub fn cancelTriggeredFires(self: *LuaEngine) void {
+        const now = clock.milliTimestamp();
         var it = self.tasks.iterator();
         while (it.next()) |entry| {
             const task = entry.value_ptr.*;
             const pf = task.pending_fire orelse continue;
-            const flag = pf.cancel orelse continue;
-            if (!flag.load(.acquire)) continue;
             if (task.scope.isCancelled()) continue;
-            task.scope.cancel("turn_cancelled") catch |err|
-                log.warn("cancelTriggeredFires: {s}", .{@errorName(err)});
+            // Turn cancelled (Ctrl+C)?
+            if (pf.cancel) |flag| {
+                if (flag.load(.acquire)) {
+                    task.scope.cancel("turn_cancelled") catch |err|
+                        log.warn("cancelTriggeredFires: {s}", .{@errorName(err)});
+                    continue;
+                }
+            }
+            // Deferred hook past its wall-clock budget? The old drain loop ran
+            // enforceBudget each iteration; restore that here for fire-bound
+            // hooks (budget_ms is null for non-hook tasks). In-process hooks
+            // keep their own drain-loop enforcement.
+            if (task.budget_ms) |budget| {
+                if (budget > 0 and now - task.started_at_ms >= budget) {
+                    task.scope.cancel("budget_exceeded") catch |err|
+                        log.warn("cancelTriggeredFires budget: {s}", .{@errorName(err)});
+                }
+            }
         }
     }
 
@@ -4142,6 +4211,53 @@ test "fireHook applies veto" {
     try std.testing.expect(reason != null);
     defer std.testing.allocator.free(reason.?);
     try std.testing.expectEqualStrings("no rm", reason.?);
+}
+
+test "beginHook defers req.done until the hook coroutine retires and surfaces its veto" {
+    var engine = try LuaEngine.init(std.testing.allocator);
+    defer engine.deinit();
+    engine.storeSelfPointer();
+    try engine.initAsync(2, 16);
+    defer engine.deinitAsync();
+
+    // A ToolPre hook that yields on zag.sleep, then vetoes.
+    try engine.lua.doString(
+        \\zag.hook("ToolPre", { pattern = "bash" }, function(evt)
+        \\  zag.sleep(5)
+        \\  return { cancel = true, reason = "no rm" }
+        \\end)
+    );
+
+    var payload: Hooks.HookPayload = .{ .tool_pre = .{
+        .name = "bash",
+        .call_id = "id1",
+        .args_json = "{\"command\":\"rm -rf /\"}",
+        .args_rewrite = null,
+    } };
+    var req = Hooks.HookRequest.init(&payload);
+    defer req.freeResult();
+
+    const deferred = engine.beginHook(&req);
+    try std.testing.expect(deferred);
+    // The hook yielded on zag.sleep; only the main-thread pump can resume it,
+    // so req.done cannot be set yet — proving the dispatch no longer parks the
+    // event loop the way the old inline drain did.
+    try std.testing.expect(!req.done.isSet());
+
+    const rt = engine.async_runtime.?;
+    var spins: usize = 0;
+    while (!req.done.isSet()) : (spins += 1) {
+        if (spins >= 100_000) return error.HookDrainTimeout;
+        if (rt.completions.pop()) |job| {
+            try engine.resumeFromJob(job);
+        } else {
+            clock.sleep(1 * std.time.ns_per_ms);
+        }
+    }
+    // finalizePendingFire stamped the aggregated veto onto the request.
+    try std.testing.expect(req.cancelled);
+    try std.testing.expectEqualStrings("no rm", req.cancel_reason.?);
+    try std.testing.expectEqual(@as(usize, 0), engine.pending_fires.items.len);
 }
 
 test "fireHook applies args rewrite" {

--- a/src/LuaEngine.zig
+++ b/src/LuaEngine.zig
@@ -362,8 +362,6 @@ pub const LuaEngine = struct {
         cancelled: bool = false,
         cancel_reason: ?[]const u8 = null,
         reason_allocator: ?Allocator = null,
-        /// Restored into `HookDispatcher.firing_depth` by finalize (hooks only).
-        hook_event_kind: ?Hooks.EventKind = null,
 
         // --- cancellation ---
         /// Borrowed cancel flag of the producing turn; the pump cancels this
@@ -2332,12 +2330,8 @@ pub const LuaEngine = struct {
             .enforceBudgetFn = sinkEnforceBudget,
         };
         self.active_hook_fire = pf;
-        const spawned = self.hook_dispatcher.beginHook(req.payload, self.lua, &sink);
+        self.hook_dispatcher.beginHook(req.payload, self.lua, &sink);
         self.active_hook_fire = null;
-        // Mark for the firing_depth decrement in finalize ONLY when the
-        // dispatcher actually incremented (spawned); a re-entry-capped fire
-        // leaves hook_event_kind null so finalize doesn't underflow the guard.
-        if (spawned) pf.hook_event_kind = req.payload.kind();
         self.releaseFireGuard(pf);
         return true;
     }
@@ -2817,10 +2811,6 @@ pub const LuaEngine = struct {
         if (!pf.finalized) {
             pf.finalized = true;
             if (pf.kind == .hook) {
-                if (pf.hook_event_kind) |k| {
-                    const d = self.hook_dispatcher.firing_depth.get(k);
-                    if (d > 0) self.hook_dispatcher.firing_depth.set(k, d - 1);
-                }
                 if (pf.bound_hook_request) |req| {
                     req.cancelled = pf.cancelled;
                     req.cancel_reason = pf.cancel_reason;
@@ -3015,6 +3005,24 @@ pub const LuaEngine = struct {
     /// propagates an error to the caller; scheduler work runs on the
     /// main thread and there is no meaningful recovery path.
     fn resumeTask(self: *LuaEngine, task: *Task, num_args_on_co: i32) void {
+        // Re-entry guard for DEFERRED hooks: elevate firing_depth[kind] only
+        // while this hook body actually runs (this resume step), so concurrent
+        // parked fires across panes never stack the counter — only a genuine
+        // same-kind re-fire from within the body (an in-process fireHook) is
+        // caught. In-process hook tasks keep the dispatcher's own guard and are
+        // excluded here (pending_fire == null) to avoid double-counting.
+        const guard_kind: ?Hooks.EventKind = if (task.pending_fire != null) blk: {
+            if (task.hook_payload) |hp| break :blk hp.kind();
+            break :blk null;
+        } else null;
+        if (guard_kind) |k| {
+            self.hook_dispatcher.firing_depth.set(k, self.hook_dispatcher.firing_depth.get(k) + 1);
+        }
+        defer if (guard_kind) |k| {
+            const d = self.hook_dispatcher.firing_depth.get(k);
+            if (d > 0) self.hook_dispatcher.firing_depth.set(k, d - 1);
+        };
+
         var num_results: i32 = 0;
         const status = task.co.resumeThread(self.lua, num_args_on_co, &num_results) catch |err| {
             const msg = task.co.toString(-1) catch "<no msg>";
@@ -4326,6 +4334,57 @@ test "concurrent deferred hook fires keep their veto scoped per fire" {
     try std.testing.expect(!req_safe.cancelled);
     try std.testing.expectEqual(@as(?[]const u8, null), req_safe.cancel_reason);
     try std.testing.expectEqual(@as(usize, 0), engine.pending_fires.items.len);
+}
+
+test "concurrent deferred hook fires beyond the recursion cap are all serviced" {
+    // Regression for the re-entry-guard-vs-concurrency fix: more ToolPre fires
+    // in flight at once than maxDepthFor(.tool_pre) (== 8) must ALL run. The
+    // guard is a recursion-depth limit (bracketed per-resume), not a cross-pane
+    // concurrency ceiling, so none of these independent fires is skipped.
+    var engine = try LuaEngine.init(std.testing.allocator);
+    defer engine.deinit();
+    engine.storeSelfPointer();
+    try engine.initAsync(4, 64);
+    defer engine.deinitAsync();
+
+    try engine.lua.doString(
+        \\zag.hook("ToolPre", function(evt)
+        \\  zag.sleep(2)
+        \\  return { cancel = true, reason = "blocked" }
+        \\end)
+    );
+
+    const n = 12; // > cap (8)
+    var payloads: [n]Hooks.HookPayload = undefined;
+    var reqs: [n]Hooks.HookRequest = undefined;
+    for (0..n) |i| {
+        payloads[i] = .{ .tool_pre = .{
+            .name = "danger",
+            .call_id = "c",
+            .args_json = "{}",
+            .args_rewrite = null,
+        } };
+        reqs[i] = Hooks.HookRequest.init(&payloads[i]);
+        try std.testing.expect(engine.beginHook(&reqs[i]));
+    }
+    defer for (0..n) |i| reqs[i].freeResult();
+
+    const rt = engine.async_runtime.?;
+    var spins: usize = 0;
+    while (engine.pending_fires.items.len > 0) : (spins += 1) {
+        if (spins >= 1_000_000) return error.HookDrainTimeout;
+        if (rt.completions.pop()) |job| {
+            try engine.resumeFromJob(job);
+        } else {
+            clock.sleep(1 * std.time.ns_per_ms);
+        }
+    }
+
+    // Every fire ran its body and vetoed — none silently dropped by the guard.
+    for (0..n) |i| {
+        try std.testing.expect(reqs[i].cancelled);
+        try std.testing.expectEqualStrings("blocked", reqs[i].cancel_reason.?);
+    }
 }
 
 test "fireHook applies args rewrite" {

--- a/src/LuaEngine.zig
+++ b/src/LuaEngine.zig
@@ -2313,6 +2313,11 @@ pub const LuaEngine = struct {
             .bound_hook_request = req,
         };
         self.pending_fires.append(self.allocator, pf) catch {
+            // Under OOM, fail safe: drop the fire and return false so the arm
+            // runs the synchronous fireHook fallback (which parks the loop for
+            // the hook's duration). Astronomically unlikely, and never a UAF or
+            // a lost req.done — just a transient loss of deferral under memory
+            // pressure.
             self.allocator.destroy(pf);
             return false;
         };
@@ -4257,6 +4262,69 @@ test "beginHook defers req.done until the hook coroutine retires and surfaces it
     // finalizePendingFire stamped the aggregated veto onto the request.
     try std.testing.expect(req.cancelled);
     try std.testing.expectEqualStrings("no rm", req.cancel_reason.?);
+    try std.testing.expectEqual(@as(usize, 0), engine.pending_fires.items.len);
+}
+
+test "concurrent deferred hook fires keep their veto scoped per fire" {
+    // Regression guard for routing veto onto the PendingFire instead of the
+    // dispatcher global: two ToolPre fires are in flight at once (both parked
+    // on zag.sleep); the hook vetoes only the "danger" tool. The veto must
+    // land on that fire's request and NOT leak onto the concurrent "safe" one.
+    var engine = try LuaEngine.init(std.testing.allocator);
+    defer engine.deinit();
+    engine.storeSelfPointer();
+    try engine.initAsync(2, 16);
+    defer engine.deinitAsync();
+
+    try engine.lua.doString(
+        \\zag.hook("ToolPre", function(evt)
+        \\  zag.sleep(5)
+        \\  if evt.name == "danger" then
+        \\    return { cancel = true, reason = "blocked" }
+        \\  end
+        \\  return nil
+        \\end)
+    );
+
+    var pd: Hooks.HookPayload = .{ .tool_pre = .{
+        .name = "danger",
+        .call_id = "d1",
+        .args_json = "{}",
+        .args_rewrite = null,
+    } };
+    var ps: Hooks.HookPayload = .{ .tool_pre = .{
+        .name = "safe",
+        .call_id = "s1",
+        .args_json = "{}",
+        .args_rewrite = null,
+    } };
+    var req_danger = Hooks.HookRequest.init(&pd);
+    defer req_danger.freeResult();
+    var req_safe = Hooks.HookRequest.init(&ps);
+    defer req_safe.freeResult();
+
+    // Both fires are registered (and parked on zag.sleep) before either is
+    // pumped, so their coroutines genuinely coexist in flight.
+    try std.testing.expect(engine.beginHook(&req_danger));
+    try std.testing.expect(engine.beginHook(&req_safe));
+    try std.testing.expect(!req_danger.done.isSet());
+    try std.testing.expect(!req_safe.done.isSet());
+
+    const rt = engine.async_runtime.?;
+    var spins: usize = 0;
+    while (!req_danger.done.isSet() or !req_safe.done.isSet()) : (spins += 1) {
+        if (spins >= 100_000) return error.HookDrainTimeout;
+        if (rt.completions.pop()) |job| {
+            try engine.resumeFromJob(job);
+        } else {
+            clock.sleep(1 * std.time.ns_per_ms);
+        }
+    }
+
+    try std.testing.expect(req_danger.cancelled);
+    try std.testing.expectEqualStrings("blocked", req_danger.cancel_reason.?);
+    try std.testing.expect(!req_safe.cancelled);
+    try std.testing.expectEqual(@as(?[]const u8, null), req_safe.cancel_reason);
     try std.testing.expectEqual(@as(usize, 0), engine.pending_fires.items.len);
 }
 

--- a/src/agent.zig
+++ b/src/agent.zig
@@ -543,6 +543,12 @@ pub fn marshalRequest(
         if (!@hasDecl(T, "freeResult")) @compileError(@typeName(T) ++ " missing 'freeResult' method");
     }
 
+    // Requests serviced as a deferred fire borrow the producing turn's cancel
+    // flag so the main-thread pump can abort them on Ctrl+C and shutdown can
+    // scope its fire-release to this runner. Generic so every cancel-bearing
+    // request type (CompactRequest, HookRequest) is wired in one place.
+    if (@hasField(T, "cancel")) req.cancel = cancel;
+
     queue.push(makeAgentEvent(T, req)) catch return error.EventQueueFull;
 
     while (true) {
@@ -1739,10 +1745,7 @@ pub fn fireCompact(
     if (est.total + reserve_tokens <= tokens_max) return .skipped;
 
     var req = agent_events.CompactRequest.init(messages, est.total, tokens_max, allocator);
-    // The deferred compaction fire borrows this flag (via its PendingFire) so
-    // the pump can abort the strategy on Ctrl+C and so shutdown can scope its
-    // fire-release to this runner.
-    req.cancel = cancel;
+    // marshalRequest threads `cancel` onto req.cancel for the deferred fire.
     marshalRequest(agent_events.CompactRequest, &req, queue, cancel) catch |err| switch (err) {
         error.EventQueueFull => return .skipped,
         error.Cancelled => return error.Cancelled,

--- a/src/lua/hook_registry.zig
+++ b/src/lua/hook_registry.zig
@@ -385,11 +385,18 @@ pub const HookDispatcher = struct {
     /// the engine's `resumeTask` when a hook coroutine retires with a
     /// return value. Table sits at the top of `co` and is NOT popped
     /// here; the caller pops via `co.pop(num_results)`.
+    /// Apply a coroutine hook's return table: mutate the payload's rewrite
+    /// slots, and — for a veto-capable kind that returned `cancel=true` —
+    /// return the duped veto reason (caller owns; dispatcher-allocated), else
+    /// null. Unlike the sync `applyHookReturn`, this does NOT touch the
+    /// dispatcher's veto channel: the caller (`resumeTask`) routes the reason
+    /// either onto the task's `PendingFire` (deferred round-trip hooks) or via
+    /// `setPendingCancel` (the in-process `fireHook` path).
     pub fn applyHookReturnFromCoroutine(
         self: *HookDispatcher,
         co: *Lua,
         payload: *Hooks.HookPayload,
-    ) !void {
+    ) !?[]const u8 {
         _ = co.getField(-1, "cancel");
         const cancel = co.isBoolean(-1) and co.toBoolean(-1);
         co.pop(1);
@@ -401,18 +408,17 @@ pub const HookDispatcher = struct {
             };
             if (!veto_allowed) {
                 log.warn("hook returned cancel=true for observer-only event {s}; ignored", .{@tagName(payload.kind())});
-                return;
+                return null;
             }
-            self.pending_cancel = true;
+            var reason: ?[]const u8 = null;
             _ = co.getField(-1, "reason");
             if (co.isString(-1)) {
                 if (co.toString(-1)) |reason_text| {
-                    if (self.pending_cancel_reason) |old| self.allocator.free(old);
-                    self.pending_cancel_reason = self.allocator.dupe(u8, reason_text) catch null;
+                    reason = self.allocator.dupe(u8, reason_text) catch null;
                 } else |_| {}
             }
             co.pop(1);
-            return;
+            return reason;
         }
 
         switch (payload.*) {
@@ -465,6 +471,17 @@ pub const HookDispatcher = struct {
             },
             else => {},
         }
+        return null;
+    }
+
+    /// Feed the in-process veto channel (read by `consumePendingCancel`).
+    /// Used by the synchronous `fireHook` path for coroutine hooks that are
+    /// NOT bound to a `PendingFire`; deferred round-trip hooks route their
+    /// veto onto their fire instead. Takes ownership of `reason`.
+    pub fn setPendingCancel(self: *HookDispatcher, reason: []const u8) void {
+        self.pending_cancel = true;
+        if (self.pending_cancel_reason) |old| self.allocator.free(old);
+        self.pending_cancel_reason = reason;
     }
 
     /// Read-and-reset the internal veto channel populated by

--- a/src/lua/hook_registry.zig
+++ b/src/lua/hook_registry.zig
@@ -228,6 +228,57 @@ pub const HookDispatcher = struct {
         return self.consumePendingCancel();
     }
 
+    /// Deferred dispatch (the round-trip `.hook_request` path): increment the
+    /// re-entry guard and spawn each matching hook as a coroutine via the sink
+    /// (which binds it to the engine's active PendingFire), then RETURN — no
+    /// drain loop, no veto consume. The caller (`LuaEngine.beginHook`) owns the
+    /// fire that tracks retirement, and the firing_depth bump is balanced by
+    /// the engine's `finalizePendingFire` (NOT a `defer` here) so the guard
+    /// stays elevated across the async window. Returns true when it incremented
+    /// the guard (caller arranges the matching decrement), false when skipped
+    /// (no hooks / re-entry capped — no increment, nothing owed).
+    pub fn beginHook(
+        self: *HookDispatcher,
+        payload: *Hooks.HookPayload,
+        lua: *Lua,
+        sink: *const ResumeSink,
+    ) bool {
+        if (self.registry.hooks.items.len == 0) return false;
+
+        const kind = payload.kind();
+        const cur_depth = self.firing_depth.get(kind);
+        const cap = maxDepthFor(kind);
+        if (cur_depth >= cap) {
+            log.warn(
+                "hook recursion depth {d} >= max {d}; skipping {s}",
+                .{ cur_depth, cap, @tagName(kind) },
+            );
+            return false;
+        }
+        self.firing_depth.set(kind, cur_depth + 1);
+
+        const pattern_key = hookPatternKey(payload.*);
+        var it = self.registry.iterMatching(kind, pattern_key);
+        while (it.next()) |hook| {
+            const top = lua.getTop();
+            _ = lua.rawGetIndex(zlua.registry_index, hook.lua_ref);
+            self.pushPayloadAsTable(lua, payload.*) catch |err| {
+                log.warn("hook payload marshalling failed for {s}: {}", .{ @tagName(kind), err });
+                lua.setTop(top);
+                continue;
+            };
+            // spawnHookFn binds the Task to the active fire and tags the
+            // payload before the first resume; a synchronously-completing hook
+            // still records its veto via resumeTask's ok-branch and decrements
+            // the fire. No `spawned` tracking needed — the fire counts.
+            _ = sink.spawnHookFn(sink.ctx, payload) catch |err| {
+                log.warn("hook spawn failed for {s}: {}", .{ @tagName(kind), err });
+                continue;
+            };
+        }
+        return true;
+    }
+
     fn anyHookAlive(self: *HookDispatcher, sink: *const ResumeSink, refs: []const i32) bool {
         _ = self;
         for (refs) |r| {

--- a/src/lua/hook_registry.zig
+++ b/src/lua/hook_registry.zig
@@ -228,35 +228,27 @@ pub const HookDispatcher = struct {
         return self.consumePendingCancel();
     }
 
-    /// Deferred dispatch (the round-trip `.hook_request` path): increment the
-    /// re-entry guard and spawn each matching hook as a coroutine via the sink
-    /// (which binds it to the engine's active PendingFire), then RETURN — no
-    /// drain loop, no veto consume. The caller (`LuaEngine.beginHook`) owns the
-    /// fire that tracks retirement, and the firing_depth bump is balanced by
-    /// the engine's `finalizePendingFire` (NOT a `defer` here) so the guard
-    /// stays elevated across the async window. Returns true when it incremented
-    /// the guard (caller arranges the matching decrement), false when skipped
-    /// (no hooks / re-entry capped — no increment, nothing owed).
+    /// Deferred dispatch (the round-trip `.hook_request` path): spawn each
+    /// matching hook as a coroutine via the sink (which binds it to the
+    /// engine's active PendingFire), then RETURN — no drain loop, no veto
+    /// consume. The caller (`LuaEngine.beginHook`) owns the fire that tracks
+    /// retirement.
+    ///
+    /// The re-entry guard is NOT applied here. A deferred fire's guard is
+    /// bracketed per-resume in `LuaEngine.resumeTask` (only while the hook body
+    /// actually executes), so concurrent parked fires across panes don't
+    /// inflate `firing_depth`; only a genuine same-kind re-fire while a hook
+    /// body is running is caught. A deferred round-trip hook cannot recurse via
+    /// the round-trip path anyway (its producing agent thread is parked on
+    /// req.done), so the only recursion vector is an in-process `fireHook` from
+    /// the body, which sees the per-resume elevation.
     pub fn beginHook(
         self: *HookDispatcher,
         payload: *Hooks.HookPayload,
         lua: *Lua,
         sink: *const ResumeSink,
-    ) bool {
-        if (self.registry.hooks.items.len == 0) return false;
-
+    ) void {
         const kind = payload.kind();
-        const cur_depth = self.firing_depth.get(kind);
-        const cap = maxDepthFor(kind);
-        if (cur_depth >= cap) {
-            log.warn(
-                "hook recursion depth {d} >= max {d}; skipping {s}",
-                .{ cur_depth, cap, @tagName(kind) },
-            );
-            return false;
-        }
-        self.firing_depth.set(kind, cur_depth + 1);
-
         const pattern_key = hookPatternKey(payload.*);
         var it = self.registry.iterMatching(kind, pattern_key);
         while (it.next()) |hook| {
@@ -276,7 +268,6 @@ pub const HookDispatcher = struct {
                 continue;
             };
         }
-        return true;
     }
 
     fn anyHookAlive(self: *HookDispatcher, sink: *const ResumeSink, refs: []const i32) bool {


### PR DESCRIPTION
## Summary

Follow-up to #18 (compaction deferral). Extends the same deferred-done machinery to **async hooks**: the round-trip `.hook_request` arm now spawns each matching hook coroutine bound to a `PendingFire` that owns `req.done` and returns without the old inline drain loop. The per-tick pump advances them; `finalizePendingFire` fires done with the per-fire-aggregated veto once the last retires. So a lifecycle/tool hook that does slow async work (e.g. `zag.llm.complete`) no longer parks the event loop the way compaction used to.

## Scope

- Converts **only the round-trip hook path** (`AgentRunner.serviceRoundTripEvent`'s `.hook_request` arm → `LuaEngine.beginHook`). The ~20 **in-process** `eng.fireHook` callers (WindowManager / EventOrchestrator / sessions pane/draft events) have no `req` to defer on and stay synchronous.
- Reuses the PendingFire shutdown/cancel machinery from #18: `marshalRequest` now threads the turn cancel flag onto any cancel-bearing request, so shutdown scoping + Ctrl+C abort reach hook fires; the hook budget (the removed drain loop enforced it) now runs from the pump in `cancelTriggeredFires`.

## Key design points

- **Per-fire veto.** `applyHookReturnFromCoroutine` returns the reason instead of writing dispatcher globals; `resumeTask` routes it onto `task.pending_fire` (deferred) or the in-process veto channel. Regression test included (two concurrent fires; veto stays scoped).
- **Re-entry guard tracks recursion, not concurrency.** The guard is bracketed per-resume in `resumeTask` (only while a hook body runs) rather than held spawn-to-finalize. This fixes a behavior change caught in review where, because panes share one engine, a held guard would have made the recursion cap (8) silently double as a cross-pane concurrency limit and drop the 9th simultaneous same-kind fire. Regression test: 12 concurrent ToolPre fires all serviced.

## Verification

- App + test build: clean
- Unit/agent tests: pass serially (0 failures; the parallel-run `drainAll`/`TestPopupListTooSlow` lines are the documented environmental flake)
- Headless E2E `validate-trajectory`: ✓ valid
- New tests: deferral proven (`!req.done.isSet()` after a yielding hook), per-fire veto isolation, and the concurrency-cap regression

## CI note

Same as #18: the Linux jobs are red on the pre-existing `os.argv` 0.16 gap (`main` is red on them too), and macOS may hit the `drainAll` env flake; neither is a regression from this PR.