### PR TITLE
Harness: block on the wake pipe while idle instead of busy-spinning

### DIFF
--- a/src/Harness.zig
+++ b/src/Harness.zig
@@ -565,6 +565,17 @@ fn runWithProvider(deps: HeadlessDeps) !void {
         const count = deps.runner.event_queue.drain(&drain_buf);
 
         if (count == 0) {
+            // Idle: block on the wake pipe instead of busy-spinning a core.
+            // Both an agent-event push (EventQueue) and a worker completion
+            // post (LuaCompletionQueue.wake_fd, wired above) write this pipe,
+            // so an in-flight deferred fire wakes us promptly. The heartbeat
+            // bounds the wait so time-based work (hook budget enforcement in
+            // cancelTriggeredFires) still runs if a wake is ever missed.
+            const idle_heartbeat_ms = 250;
+            var fds = [_]posix.pollfd{
+                .{ .fd = deps.wake_read_fd, .events = posix.POLL.IN, .revents = 0 },
+            };
+            _ = posix.poll(&fds, idle_heartbeat_ms) catch {};
             var wake_buf: [64]u8 = undefined;
             _ = wake_pipe.read(deps.wake_read_fd, &wake_buf) catch {};
             continue;


### PR DESCRIPTION
## Summary

The deferred-done work (#18, #19) means a compaction/hook fire's worker now runs while the headless agent loop is otherwise idle. That loop's `count == 0` path was a non-blocking `wake_pipe.read` + `continue` — a busy-spin that pegs a core for the fire's whole duration.

This blocks on the wake pipe via `posix.poll` instead (mirroring the interactive driver). Both agent-event pushes (`EventQueue`) and worker completion posts (`LuaCompletionQueue.wake_fd`) write that pipe, so an in-flight deferred fire wakes the loop promptly. A 250ms heartbeat bounds the wait so time-based work (hook-budget enforcement in `cancelTriggeredFires`) still runs if a wake is ever missed.

## Verification
- Build: clean
- Unit/agent tests: 2069 pass, 0 failed (serial)
- Headless E2E `validate-trajectory`: ✓ valid (the loop still drives a real run correctly)

## CI note
Same pre-existing reds as #18/#19 (Linux `os.argv` 0.16 gap; `drainAll` macOS flake) — not regressions.