### PR TITLE
Harden deferred-done hooks: fix re-entrancy mis-bind + review minors

### DIFF
--- a/src/LuaEngine.zig
+++ b/src/LuaEngine.zig
@@ -2274,6 +2274,17 @@ pub const LuaEngine = struct {
     pub fn fireHook(self: *LuaEngine, payload: *Hooks.HookPayload) !?[]const u8 {
         if (self.hook_dispatcher.registry.hooks.items.len == 0) return null;
 
+        // This is the IN-PROCESS fire path. It must never bind its coroutines
+        // to a deferred fire, even when re-entered synchronously from inside a
+        // deferred hook body (a deferred hook's first resume runs inline inside
+        // beginHook, where `active_hook_fire` is set; a body that fires an
+        // in-process hook from there must not have it bound to the outer fire).
+        // Disown any active fire for our duration so `sinkSpawnHook` spawns
+        // unbound (in-process) coroutines.
+        const saved_fire = self.active_hook_fire;
+        self.active_hook_fire = null;
+        defer self.active_hook_fire = saved_fire;
+
         // No async runtime → legacy synchronous protectedCall path. The
         // dispatcher handles it directly; no sink needed.
         if (self.async_runtime == null) {
@@ -2865,6 +2876,11 @@ pub const LuaEngine = struct {
                 .hook => {}, // HookRequest has no error field; done is enough
             }
             pf.done.set();
+            // Sever the borrowed cancel-flag pointer too: the fire lingers in
+            // `pending_fires` until its coroutine retires, and `cancelTriggeredFires`
+            // dereferences `pf.cancel` every tick — once the producer is released
+            // its flag storage may die, so a dangling read is otherwise possible.
+            pf.cancel = null;
         }
         var it = self.tasks.valueIterator();
         while (it.next()) |task_ptr| {
@@ -4271,6 +4287,44 @@ test "beginHook defers req.done until the hook coroutine retires and surfaces it
     try std.testing.expect(req.cancelled);
     try std.testing.expectEqualStrings("no rm", req.cancel_reason.?);
     try std.testing.expectEqual(@as(usize, 0), engine.pending_fires.items.len);
+}
+
+test "in-process fireHook disowns an active deferred fire (re-entrancy mis-bind guard)" {
+    // A deferred hook body that synchronously fires an in-process hook must not
+    // have that in-process hook bound to the outer deferred fire. Simulate the
+    // mid-beginHook state (active_hook_fire set), fire an in-process veto hook,
+    // and assert its veto surfaces via the in-process channel — never routed
+    // onto the outer fire, whose state stays untouched.
+    var engine = try LuaEngine.init(std.testing.allocator);
+    defer engine.deinit();
+    engine.storeSelfPointer();
+    try engine.initAsync(2, 16);
+    defer engine.deinitAsync();
+
+    try engine.lua.doString(
+        \\zag.hook("ToolPre", function(evt) return { cancel = true, reason = "inner" } end)
+    );
+
+    var done_evt: sync.ResetEvent = .{};
+    var outer_pf: LuaEngine.PendingFire = .{ .kind = .hook, .done = &done_evt, .outstanding = 1 };
+    engine.active_hook_fire = &outer_pf;
+
+    var payload: Hooks.HookPayload = .{ .tool_pre = .{
+        .name = "bash",
+        .call_id = "id1",
+        .args_json = "{}",
+        .args_rewrite = null,
+    } };
+    const reason = try engine.fireHook(&payload);
+
+    // Veto came back via the in-process return, NOT onto the outer fire.
+    try std.testing.expect(reason != null);
+    try std.testing.expectEqualStrings("inner", reason.?);
+    try std.testing.expect(!outer_pf.cancelled);
+    try std.testing.expectEqual(@as(usize, 1), outer_pf.outstanding);
+
+    if (reason) |r| engine.hook_dispatcher.allocator.free(r);
+    engine.active_hook_fire = null;
 }
 
 test "concurrent deferred hook fires keep their veto scoped per fire" {

--- a/src/WindowManager.zig
+++ b/src/WindowManager.zig
@@ -2384,6 +2384,15 @@ fn swapProviderOnPanePtr(
             var waited_ms: u64 = 0;
             while (runner.isAgentRunning()) : (waited_ms += 1) {
                 if (waited_ms >= timeout_ms) return error.SwapTimeout;
+                // Run the engine pump here too: a turn parked mid-compaction
+                // (or in an async hook) only makes progress when something
+                // aborts its fire (cancelAgent set the flag above) and pumps
+                // the completion that retires the coroutine. Without this the
+                // cancelled turn can't unwind and the loop hits SwapTimeout.
+                if (runner.lua_engine) |eng| {
+                    eng.cancelTriggeredFires();
+                    eng.pumpCompletions();
+                }
                 _ = runner.drainEvents();
                 clock.sleep(1 * std.time.ns_per_ms);
             }

--- a/src/lua/hook_registry.zig
+++ b/src/lua/hook_registry.zig
@@ -357,6 +357,7 @@ pub const HookDispatcher = struct {
                 return;
             }
             self.pending_cancel = true;
+            var got_reason = false;
             _ = lua.getField(-1, "reason");
             if (lua.isString(-1)) {
                 // Borrowed from Lua VM; must be duped before the pop below.
@@ -364,9 +365,17 @@ pub const HookDispatcher = struct {
                     // Free any previously stored reason before overwriting.
                     if (self.pending_cancel_reason) |old| self.allocator.free(old);
                     self.pending_cancel_reason = self.allocator.dupe(u8, reason_text) catch null;
+                    got_reason = true;
                 } else |_| {}
             }
             lua.pop(1);
+            // A reason-less `cancel = true` still vetoes: store an empty reason
+            // so consumePendingCancel returns a non-null value the caller routes
+            // as a real veto (matches applyHookReturnFromCoroutine).
+            if (!got_reason) {
+                if (self.pending_cancel_reason) |old| self.allocator.free(old);
+                self.pending_cancel_reason = self.allocator.dupe(u8, "") catch null;
+            }
             return;
         }
 
@@ -460,7 +469,11 @@ pub const HookDispatcher = struct {
                 } else |_| {}
             }
             co.pop(1);
-            return reason;
+            // A `cancel = true` veto takes effect even without a reason string.
+            // Return an empty (non-null) reason so the caller routes it as a
+            // real veto instead of silently dropping it (the reason is surfaced
+            // to the producer as `cancelled` with an empty `cancel_reason`).
+            return reason orelse (self.allocator.dupe(u8, "") catch null);
         }
 
         switch (payload.*) {


### PR DESCRIPTION
## Summary

A six-agent parallel review of the merged deferred-done work (#18/#19/#20) found one real correctness bug plus a few worthwhile minors. This PR fixes them.

## MAJOR — `active_hook_fire` re-entrancy mis-bind (independently found by two reviewers)

`beginHook` sets `self.active_hook_fire = pf` for the whole dispatcher spawn loop, which resumes each hook body **inline**. If a deferred hook body (e.g. a `tool_pre` hook) synchronously triggers an **in-process** `fireHook` — reachable, e.g. a session-mutating binding → `fireSessionListChanged → engine.fireHook` — `sinkSpawnHook` still saw the outer `pf` and bound that unrelated in-process hook to it. Consequences: the inner hook's **veto routed to the wrong request**, it delayed the outer fire's `req.done`, and a Ctrl+C/shutdown scoped to the outer turn spuriously cancelled it.

**Fix:** the in-process `fireHook` saves/nulls/restores `active_hook_fire`, so it never binds to a deferred fire. **RED-verified regression test** included (disabling the fix makes it fail).

## Minors

- **`pf.cancel` sever at shutdown** — `failFiresMatching` now nulls `pf.cancel` when releasing a fire, so the per-tick `cancelTriggeredFires` can't dereference a borrowed cancel flag whose storage dies before the lingering fire retires (was safe only by teardown ordering).
- **`swapProvider` pump** — the provider-swap drain loop cancelled the agent but never ran the engine pump, so a turn parked mid-compaction could only end via the 5s `SwapTimeout`. It now pumps each iteration so the cancelled turn actually drains.
- **Reason-less veto** — a hook returning `{cancel = true}` with no reason was silently dropped on both veto paths; it now takes effect (empty `cancel_reason`).

## Verification
- Build: clean
- Unit/agent tests: 2071 pass, 0 failed (serial); the MAJOR fix is RED-verified
- The `drainAll` macOS flake / Linux `os.argv` gap are pre-existing, not regressions